### PR TITLE
Add 'remove diacritics' option

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -4,7 +4,8 @@ class Base {
       triggerEventName = false,
       elements = false,
       success: callbackSuccess,
-      error: callbackError
+      error: callbackError,
+      removeDiacritics = false
     } = object;
 
     let {
@@ -24,6 +25,7 @@ class Base {
     this.stateEl = stateEl;
 
     this.triggerEventName = triggerEventName;
+    this.removeDiacritics = removeDiacritics;
     this.callbackSuccess = callbackSuccess || false;
     this.callbackError = callbackError || false;
   }

--- a/src/search.js
+++ b/src/search.js
@@ -45,10 +45,29 @@ class Search {
   fillForm(data) {
     this.streetEl.value = `${data.tipoDeLogradouro} ${data.logradouro}`;
     this.neighborhoodEl.value = data.bairro;
-    this.cityEl.value = data.cidade;
+    var cityValue = data.cidade;
+    if (this.removeDiacritics) {
+      cityValue = this.replaceDiacritics(cityValue);
+    }
+    this.cityEl.value = cityValue;
     this.stateEl.value = data.estado;
 
     this.numberEl.focus();
+  }
+
+  replaceDiacritics(str) {
+    str = str.replace(/[ÁÀÂÃÄ]/g, 'A');
+    str = str.replace(/[áàâãä]/g, 'a');
+    str = str.replace(/[ÉÈÊË]/g, 'E');
+    str = str.replace(/[éèêë]/g, 'e');
+    str = str.replace(/[ÍÌÎÏ]/g, 'I');
+    str = str.replace(/[íìîï]/g, 'i');
+    str = str.replace(/[ÓÒÔÕÖ]/g, 'O');
+    str = str.replace(/[óòôõö]/g, 'o');
+    str = str.replace(/[ÚÙÛÜ]/g, 'U');
+    str = str.replace(/[úùûü]/g, 'u');
+    str = str.replace(/[Ç]/g, 'C');
+    return str.replace(/[ç]/g, 'c');
   }
 }
 

--- a/test/unit/base.js
+++ b/test/unit/base.js
@@ -208,5 +208,25 @@ describe('Base', () => {
         expect(base.searchEl({ el })).to.not.equal(undefined);
       });
     });
+
+    describe('when removeDiacritics is empty', () => {
+      beforeEach(() => {
+        base = new Base();
+      });
+
+      it('removeDiacritics is false', () => {
+        expect(base.removeDiacritics).to.equal(false);
+      });
+    });
+
+    describe('when removeDiacritics exists', () => {
+      beforeEach(() => {
+        base = new Base({ removeDiacritics: true });
+      });
+
+      it('returns the value passed on removeDiacritics option', () => {
+        expect(base.removeDiacritics).to.equal(true);
+      });
+    });
   });
 });

--- a/test/unit/search.js
+++ b/test/unit/search.js
@@ -114,17 +114,43 @@ describe('Search', () => {
           fooInstance.search();
         });
 
-        it('when success has been fill form', () => {
-          let fooInstance = new Foo();
+        describe('with removeDiacritics option set to false', () => {
+          it('fills the form with diacritics', () => {
+            let fooInstance = new Foo({ removeDiacritics: false });
 
-          fooInstance.fillForm({ tipoDeLogradouro: 'Rua', logradouro: 'logradouro', bairro: 'bairro', cidade: 'cidade', estado: 'estado' });
+            fooInstance.fillForm({ tipoDeLogradouro: 'Rua', logradouro: 'logradouro', bairro: 'bairro', cidade: 'cidáde', estado: 'estado' });
 
-          expect(fooInstance.streetEl.value).to.equal('Rua logradouro');
-          expect(fooInstance.neighborhoodEl.value).to.equal('bairro');
-          expect(fooInstance.cityEl.value).to.equal('cidade');
-          expect(fooInstance.stateEl.value).to.equal('estado');
+            expect(fooInstance.streetEl.value).to.equal('Rua logradouro');
+            expect(fooInstance.neighborhoodEl.value).to.equal('bairro');
+            expect(fooInstance.cityEl.value).to.equal('cidáde');
+            expect(fooInstance.stateEl.value).to.equal('estado');
+          });
+        });
+        describe('with removeDiacritics option set to true', () => {
+          it('fills the form without diacritics', () => {
+            let fooInstance = new Foo({ removeDiacritics: true });
+
+            fooInstance.fillForm({ tipoDeLogradouro: 'Rua', logradouro: 'logradouro', bairro: 'bairro', cidade: 'cidáde', estado: 'estado' });
+
+            expect(fooInstance.streetEl.value).to.equal('Rua logradouro');
+            expect(fooInstance.neighborhoodEl.value).to.equal('bairro');
+            expect(fooInstance.cityEl.value).to.equal('cidade');
+            expect(fooInstance.stateEl.value).to.equal('estado');
+          });
         });
       });
+    });
+  });
+
+  describe('replaceDiacritics function', () => {
+    beforeEach(() => {
+      fooInstance = new Foo();
+    });
+
+    it('replaces diacritics with ascii characters', () => {
+      var input = 'AÁÀÂÃÄaáàâãäEÉÈÊËeéèêëIÍÌÎÏiíìîïOÓÒÔÕÖoóòôõöUÚÙÛÜuúùûüCÇcç';
+      var expected = 'AAAAAAaaaaaaEEEEEeeeeeIIIIIiiiiiOOOOOOooooooUUUUUuuuuuCCcc';
+      expect(fooInstance.replaceDiacritics(input)).to.equal(expected);
     });
   });
 });


### PR DESCRIPTION
### What

Add `remove diacritics` option.
### How?

Replacing diacritics for ASCII characters.

Example:
City name is `Niterói`.
Removing diacritics it becomes `Niteroi`.
### Why?

Because sometimes the cities are registered without diacritics on the user's database.
